### PR TITLE
Micrometer metrics exposed by C8B - made available for prometheus scraping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ out/
 runner/testruns/**
 runner/testruns-done/**
 runner/current/run
+
+application.yml

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ runner/testruns/**
 runner/testruns-done/**
 runner/current/run
 
-application.yml
+src/main/resources/application.yml

--- a/src/main/resources/benchmarktemplates/Makefile
+++ b/src/main/resources/benchmarktemplates/Makefile
@@ -5,7 +5,7 @@ release ?= camunda
 # Helm chart coordinates for Camunda
 chart ?= camunda/camunda-platform
 
-chartValues ?= "camunda-values.yaml"
+chartValues ?= camunda-values.yaml --version=${engine.helmChartVersion}
 
 # TODO configure through runner
 modelDir ?= ../../../models
@@ -84,6 +84,8 @@ benchmark: namespace copy-models
 #	kubectl create configmap msg-scenario --from-file=msg-scenario.json=models/msg-scenario.json -n $(namespace)
 	kubectl create configmap msg-scenario --from-file=msg-scenario.json=models/$(scenario) -n $(namespace)
 	kubectl apply -f $(benchmark)                                                          -n $(namespace)
+	kubectl expose deployment benchmark --type=ClusterIP   --name=benchmark-svc  --port=8088 --target-port=8088
+	kubectl apply -f benchmark-service-monitor.yaml -n $(namespace)
 # TODO automatically switch/generate benchmark config
 
 .PHONY: clean-benchmark

--- a/src/main/resources/benchmarktemplates/benchmark-service-monitor.yaml
+++ b/src/main/resources/benchmarktemplates/benchmark-service-monitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: benchmark
+    release: metrics
+  name: benchmark
+  namespace: camunda
+
+spec:
+  endpoints:
+    - honorLabels: true
+      interval: 10s
+      path: /actuator/prometheus
+  selector:
+    matchLabels:
+      app: benchmark

--- a/src/main/resources/benchmarktemplates/benchmark.yaml
+++ b/src/main/resources/benchmarktemplates/benchmark.yaml
@@ -27,7 +27,7 @@ spec:
               -Dcamunda.client.zeebe.prefer-rest-over-grpc=false
               -Dzeebe.client.request-timeout=600s
               -Dzeebe.client.job.poll-interval=1ms
-              -Dzeebe.client.default-job-worker-stream-enabled=true
+              -Dcamunda.client.zeebe.default-job-worker-stream-enabled=true
               -Dbenchmark.bpmnProcessId=${loadGeneratorStarter.processModel}
               -Dbenchmark.startPiPerSecond=${loadGeneratorStarter.startThroughput}
               -Dbenchmark.startPiIncreaseFactor=${loadGeneratorStarter.startPiIncreaseFactor}
@@ -44,11 +44,11 @@ spec:
 #              -Dzeebe.client.worker.threads=${jobWorker.numberOfThreads}
         resources:
           limits:
-            cpu: ${engine.vcpus}
-            memory: ${engine.ram}Gi
+            cpu: ${jobWorker.vcpus}
+            memory: ${jobWorker.ram}Gi
           requests:
-            cpu: 1
-            memory: 1Gi
+            cpu: ${jobWorker.vcpus}
+            memory: ${jobWorker.ram}Gi
         volumeMounts:
         - name: payload
           mountPath: ${loadGeneratorStarter.payload}

--- a/src/main/resources/benchmarktemplates/camunda-values.yaml
+++ b/src/main/resources/benchmarktemplates/camunda-values.yaml
@@ -128,10 +128,8 @@ operate:
       cpu: ${operate.vcpus}
       memory: ${operate.ram}Gi
   env:
-    - name: CAMUNDA_OPERATE_IMPORTER_READERTHREADSCOUNT
-      value: "${operate.importerReaderthreadscount}"
     - name: CAMUNDA_OPERATE_IMPORTER_THREADSCOUNT
-      value: "${operate.importerThreadscount}"
+      value: "${operate.importerThreads}"
     - name: CAMUNDA_OPERATE_ELASTICSEARCH_NUMBEROFSHARDS
       value: "${elasticSearch.shardsPerIndex}"
 tasklist:


### PR DESCRIPTION
- Added service monitor to benchmark pod to enable prometheus scraping for metrics exposed by C8B
- One can now create grafana charts based on c8b micrometer metrics
- Parameterized helmchart version from testcase inputs
- Operate threadcount variable renamed